### PR TITLE
chore: bump softprops/action-gh-release to v3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
           zip air-sviva-custom-component.zip -r .
 
       - name: "Upload release artifact"
-        uses: "softprops/action-gh-release@v2.6.1"
+        uses: "softprops/action-gh-release@v3"
         with:
           name: "Air Sviva Custom Component"
           files: "release/air-sviva-custom-component.zip"


### PR DESCRIPTION
Bumps `softprops/action-gh-release` from v2 to v3.