### PR TITLE
fix: address HIGH and MEDIUM issues from code review

### DIFF
--- a/custom_components/air_sviva/config_flow.py
+++ b/custom_components/air_sviva/config_flow.py
@@ -126,21 +126,19 @@ class AirSvivaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ign
             LOGGER.error("Station selection step reached but no region selected")
             return self.async_abort(reason="unknown")
 
-        stations = self._stations_by_region.get(self._selected_region_id, [])
-        active_stations = [s for s in stations if getattr(s, "active", False)]
+        active_stations = self._stations_by_region.get(self._selected_region_id, [])
 
         if not active_stations:
             LOGGER.warning(
-                "No active stations in region %s (total stations: %d)",
+                "No active stations in region %s",
                 self._selected_region_id,
-                len(stations),
             )
             return self.async_abort(reason="no_stations")
 
         if user_input is not None and CONF_STATION_ID in user_input:
             station_id = user_input[CONF_STATION_ID]
             selected_station = next(
-                (s for s in stations if s.station_id == station_id), None
+                (s for s in active_stations if s.station_id == station_id), None
             )
             if selected_station:
                 LOGGER.debug("Selected station: %s", selected_station.name)
@@ -155,7 +153,7 @@ class AirSvivaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ign
             LOGGER.error(
                 "Selected station_id %s not found in stations list (available: %s)",
                 station_id,
-                [s.station_id for s in stations],
+                [s.station_id for s in active_stations],
             )
             errors["base"] = "invalid_station"
 

--- a/custom_components/air_sviva/const.py
+++ b/custom_components/air_sviva/const.py
@@ -18,5 +18,3 @@ SCAN_INTERVAL = timedelta(minutes=10)
 DEFAULT_HOURS_BACK = 4
 
 PLATFORMS: list[Platform] = [Platform.SENSOR]
-
-SERVICE_DEBUG_GET_COORDINATOR_DATA = "debug_get_coordinator_data"

--- a/custom_components/air_sviva/coordinator.py
+++ b/custom_components/air_sviva/coordinator.py
@@ -2,13 +2,12 @@
 
 from __future__ import annotations
 
-from datetime import timedelta
 from typing import TYPE_CHECKING, Any
 
 from air_sviva_api.models.exceptions import SvivaAirError
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import DOMAIN, LOGGER, SCAN_INTERVAL
+from .const import CONF_REGION_ID, CONF_STATION_ID, DOMAIN, LOGGER, SCAN_INTERVAL
 
 if TYPE_CHECKING:
     from air_sviva_api.client import SvivaAirClient
@@ -56,14 +55,14 @@ class AirSvivaUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     def __init__(self, hass: HomeAssistant, config_entry: ConfigEntry) -> None:
         """Initialize the coordinator."""
-        self._station_id = config_entry.data["station_id"]
-        self._region_id = config_entry.data["region_id"]
+        self._station_id = config_entry.data[CONF_STATION_ID]
+        self._region_id = config_entry.data[CONF_REGION_ID]
 
         super().__init__(
             hass=hass,
             logger=LOGGER,
             name=DOMAIN,
-            update_interval=timedelta(minutes=SCAN_INTERVAL.total_seconds() / 60),
+            update_interval=SCAN_INTERVAL,
         )
         self.config_entry = config_entry
 
@@ -72,11 +71,9 @@ class AirSvivaUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         client: SvivaAirClient = entry_data.client
 
         try:
-            # Fetch latest data for all regions (station could be in any region)
-            # Using hours_back=4 to get recent data
-            all_regions = [r.region_id for r in (await client.get_regions())]
+            # Fetch latest data for the configured station's region
             response: list[RegionStationData] = await client.get_regions_latest_data(
-                region_ids=all_regions,
+                region_ids=[self._region_id],
                 hours_back=4,
             )
         except SvivaAirError as exc:

--- a/custom_components/air_sviva/sensor.py
+++ b/custom_components/air_sviva/sensor.py
@@ -94,7 +94,6 @@ class AirSvivaSensor(AirSvivaEntity, SensorEntity):
         # Check if this is wind direction for circular sensor handling
         self._is_wind_direction = pollutant.upper() in ("WD", "WDD")
 
-        self._attr_native_value = init_data.channel_data.get("value")
         units = init_data.channel_data.get("units") or "AQI"
         self._attr_native_unit_of_measurement = units
 

--- a/custom_components/air_sviva/translations/en.json
+++ b/custom_components/air_sviva/translations/en.json
@@ -29,8 +29,8 @@
         "sensor": {
             "so2": { "name": "SO₂" },
             "no2": { "name": "NO₂" },
-"no": { "name": "NO" },
-"nox": { "name": "NOₓ" },
+            "no": { "name": "NO" },
+            "nox": { "name": "NOₓ" },
             "o3": {"name": "O₃"},
             "pm2_5": {"name": "PM2.5"},
             "pm10": {"name": "PM10"},


### PR DESCRIPTION
## Summary

Fixes 2 HIGH and 5 MEDIUM issues identified during code review. All changes pass ruff lint, ruff format, and mypy type checking.

### Fixes

**HIGH**
- **H1** (coordinator.py): Use `CONF_STATION_ID` / `CONF_REGION_ID` constants instead of magic strings `"station_id"` / `"region_id"`
- **H2** (en.json): Fix broken indentation on `no` and `nox` translation entries

**MEDIUM**
- **M1** (coordinator.py): Remove redundant `get_regions()` API call on every 10-minute update cycle — now fetches only the configured station's region
- **M2** (coordinator.py): Use `SCAN_INTERVAL` directly instead of `timedelta(minutes=SCAN_INTERVAL.total_seconds() / 60)`
- **M3** (sensor.py): Remove dead `_attr_native_value` assignment (always overridden by `native_value` property)
- **M4** (const.py): Remove unused constant `SERVICE_DEBUG_GET_COORDINATOR_DATA`
- **M5** (config_flow.py): Remove redundant active station filter in `async_step_select_station` (already filtered in `_build_stations_by_region`)

### Commits

| Commit | Description | Files |
| ------ | ----------- | ----- |
| `30ae3f7` | fix(coordinator): use constants, fix scan interval, remove redundant API call | coordinator.py |
| `5dae5b6` | fix(translations): fix indentation in en.json | en.json |
| `6edad52` | refactor(sensor): remove dead _attr_native_value assignment | sensor.py |
| `22bc113` | chore(const): remove unused constant | const.py |
| `bd54353` | refactor(config_flow): remove redundant active station filter | config_flow.py |

### Verification

- ✅ `ruff check` — all clean
- ✅ `ruff format --check` — all formatted
- ✅ `mypy` — no errors