### PR TITLE
chore: bump air-sviva-api dependency to 0.0.2

### DIFF
--- a/custom_components/air_sviva/manifest.json
+++ b/custom_components/air_sviva/manifest.json
@@ -9,6 +9,6 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/GuyKh/air-sviva-custom-component/issues",
   "loggers": ["air_sviva", "air_sviva_api"],
-  "requirements": ["air-sviva-api==0.0.1"],
+  "requirements": ["air-sviva-api==0.0.2"],
   "version": "0.0.1"
 }


### PR DESCRIPTION
Bumps `air-sviva-api` from `0.0.1` to `0.0.2`.

**0.0.2 includes:** [py-air-sviva-api#10](https://github.com/GuyKh/py-air-sviva-api/pull/10) — fixes the broken token refresh that caused all API calls to fail after ~1 hour.

- ✅ `ruff check` — all checks passed
- ✅ `mypy` — type check passed