### PR TITLE
Add official air quality index sensor

### DIFF
--- a/custom_components/air_sviva/__init__.py
+++ b/custom_components/air_sviva/__init__.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from air_sviva_api.client import SvivaAirClient
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.loader import async_get_loaded_integration
 
+from .api import SvivaAirClient
 from .const import (
     CONF_REGION_ID,
     CONF_STATION_ID,

--- a/custom_components/air_sviva/api.py
+++ b/custom_components/air_sviva/api.py
@@ -107,6 +107,23 @@ class RegionStationData:
     region_data: RegionData | None = None
 
 
+@dataclass
+class StationIndexData:
+    """Latest official air quality index data for a station."""
+
+    station_id: int
+    datetime: str | None = None
+    pollutant: str | None = None
+    index_id: int | None = None
+    index: float | None = None
+    value: float | None = None
+    color: str | None = None
+    description: str | None = None
+    pollutant_id: int | None = None
+    pollutant_time_base: int | None = None
+    indexes: list[dict[str, Any]] | None = None
+
+
 def _fallback_url(url: str) -> str | None:
     parsed = urlparse(url)
     replacement = FALLBACK_DOMAINS.get(parsed.netloc)
@@ -181,6 +198,22 @@ def _channel_from_dict(data: dict[str, Any]) -> ChannelReading:
         active=bool(data.get("active")),
         pollutant_id=data.get("pollutantId"),
         datetime=data.get("datetime"),
+    )
+
+
+def _station_index_from_dict(data: dict[str, Any]) -> StationIndexData:
+    return StationIndexData(
+        station_id=data["stationId"],
+        datetime=data.get("datetime"),
+        pollutant=data.get("pollutant"),
+        index_id=data.get("indexId"),
+        index=data.get("index"),
+        value=data.get("value"),
+        color=data.get("color"),
+        description=data.get("description"),
+        pollutant_id=data.get("pollutantId"),
+        pollutant_time_base=data.get("PollutantTimeBase"),
+        indexes=data.get("indexes"),
     )
 
 
@@ -333,3 +366,23 @@ class SvivaAirClient:
                 )
             )
         return stations
+
+    async def get_stations_latest_index(
+        self,
+        region_ids: list[int],
+        hours_back: int = 24,
+    ) -> list[StationIndexData]:
+        """Get latest official index data for the requested regions."""
+        ids = ",".join(str(region_id) for region_id in region_ids)
+        query = f"?unitConversion=true&regionsIds={ids}&hoursBack={hours_back}"
+        response = await self._authorized_request(
+            "GET",
+            BASE_URL + "stations/index/latest" + query,
+        )
+        if not isinstance(response, dict):
+            return []
+        return [
+            _station_index_from_dict(item)
+            for item in (response.get("data") or [])
+            if item.get("stationId") is not None
+        ]

--- a/custom_components/air_sviva/api.py
+++ b/custom_components/air_sviva/api.py
@@ -1,0 +1,335 @@
+"""Small Air Sviva API client for this Home Assistant integration."""
+
+from __future__ import annotations
+
+import base64
+import json
+import time
+import uuid
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlparse, urlunparse
+
+from aiohttp import ClientError, ClientResponse, ClientSession
+
+MAIN_URL = "https://air.sviva.gov.il/"
+BASE_URL = "https://air-papi.sviva.gov.il/v1/envista/"
+AUTH_GENERATION_URL = "https://air-papi.sviva.gov.il/v1/GenerateToken"
+GUEST_API_URL = "https://air.sviva.gov.il/Account/GetApiToken"
+
+PRIMARY_DOMAIN = "air-papi.sviva.gov.il"
+SECONDARY_DOMAIN = "air-api.sviva.gov.il"
+FALLBACK_DOMAINS = {
+    PRIMARY_DOMAIN: SECONDARY_DOMAIN,
+    SECONDARY_DOMAIN: PRIMARY_DOMAIN,
+}
+RETRYABLE_STATUS_CODES = {404, 406, 500, 502, 503, 504}
+AUTH_TOKEN_MAX_AGE_SECONDS = 45 * 60
+
+HEADERS = {
+    "accept": "application/json, text/plain, */*",
+    "accept-language": "en,he;q=0.9",
+    "origin": MAIN_URL.rstrip("/"),
+    "referer": MAIN_URL,
+    "domainname": "sviva",
+    "envi-data-source": "MANA",
+    "user-agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+    ),
+}
+
+
+class SvivaAirError(Exception):
+    """Raised when the Air Sviva API request fails."""
+
+
+@dataclass
+class Location:
+    """Station location."""
+
+    latitude: float | None = None
+    longitude: float | None = None
+
+
+@dataclass
+class Station:
+    """Air monitoring station."""
+
+    station_id: int
+    name: str
+    short_name: str | None = None
+    city: str | None = None
+    address: str | None = None
+    active: bool = False
+    location: Location | None = None
+
+
+@dataclass
+class Region:
+    """Air monitoring region."""
+
+    region_id: int
+    name: str
+    stations: list[Station] | None = None
+
+
+@dataclass
+class ChannelReading:
+    """Latest channel reading."""
+
+    id: int | None = None
+    name: str = ""
+    alias: str | None = None
+    value: float | None = None
+    status: int | None = None
+    valid: bool = False
+    description: str | None = None
+    units: str | None = None
+    active: bool = False
+    pollutant_id: int | None = None
+    datetime: str | None = None
+
+
+@dataclass
+class RegionData:
+    """Latest readings for a station."""
+
+    datetime: str | None = None
+    channels: list[ChannelReading] | None = None
+
+
+@dataclass
+class RegionStationData:
+    """Latest station data response item."""
+
+    station_id: int
+    region_data: RegionData | None = None
+
+
+def _fallback_url(url: str) -> str | None:
+    parsed = urlparse(url)
+    replacement = FALLBACK_DOMAINS.get(parsed.netloc)
+    if replacement is None:
+        return None
+    return urlunparse(parsed._replace(netloc=replacement))
+
+
+def _jwt_expired(
+    token: str,
+    generated_at: float,
+    buffer_seconds: int = 60,
+) -> bool:
+    if time.time() - generated_at >= AUTH_TOKEN_MAX_AGE_SECONDS:
+        return True
+
+    parts = token.split(".")
+    if len(parts) != 3:
+        return False
+    try:
+        payload = parts[1]
+        payload += "=" * (-len(payload) % 4)
+        decoded = json.loads(base64.urlsafe_b64decode(payload).decode("utf-8"))
+    except (ValueError, json.JSONDecodeError):
+        return False
+    exp = decoded.get("exp")
+    return exp is not None and int(time.time()) + buffer_seconds >= exp
+
+
+async def _json_or_text(response: ClientResponse) -> Any:
+    text = await response.text()
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return text
+
+
+def _clean_token(token: Any) -> str:
+    if isinstance(token, str):
+        return token.strip().replace('"', "")
+    return str(token)
+
+
+def _station_from_dict(data: dict[str, Any]) -> Station:
+    location = data.get("location") or {}
+    return Station(
+        station_id=data["stationId"],
+        name=data.get("name") or "",
+        short_name=data.get("shortName"),
+        city=data.get("city"),
+        address=data.get("address"),
+        active=bool(data.get("active")),
+        location=Location(
+            latitude=location.get("latitude"),
+            longitude=location.get("longitude"),
+        )
+        if location
+        else None,
+    )
+
+
+def _channel_from_dict(data: dict[str, Any]) -> ChannelReading:
+    return ChannelReading(
+        id=data.get("id"),
+        name=data.get("name") or "",
+        alias=data.get("alias"),
+        value=data.get("value"),
+        status=data.get("status"),
+        valid=bool(data.get("valid")),
+        description=data.get("description"),
+        units=data.get("units"),
+        active=bool(data.get("active")),
+        pollutant_id=data.get("pollutantId"),
+        datetime=data.get("datetime"),
+    )
+
+
+class SvivaAirClient:
+    """Async client for the public Air Sviva API."""
+
+    def __init__(self, session: ClientSession) -> None:
+        """Initialize the client."""
+        self._session = session
+        self._request_verification_token = str(uuid.uuid4())
+        self._auth_token: str | None = None
+        self._auth_token_generated_at = 0.0
+
+    def _headers(self) -> dict[str, str]:
+        headers = dict(HEADERS)
+        headers["x-requestverificationtoken"] = self._request_verification_token
+        if self._auth_token:
+            headers["authorization"] = f"JwtToken {self._auth_token}"
+        return headers
+
+    async def _request(
+        self,
+        method: str,
+        url: str,
+        headers: dict[str, str],
+        json_data: dict[str, Any] | None = None,
+    ) -> Any:
+        urls = [url]
+        fallback = _fallback_url(url)
+        if fallback:
+            urls.append(fallback)
+
+        last_error: Exception | None = None
+        for attempt_url in urls:
+            try:
+                async with self._session.request(
+                    method,
+                    attempt_url,
+                    headers=headers,
+                    json=json_data,
+                    timeout=30,
+                ) as response:
+                    payload = await _json_or_text(response)
+                    if response.status == 200:
+                        return payload
+                    if response.status in RETRYABLE_STATUS_CODES:
+                        last_error = SvivaAirError(
+                            f"API returned status {response.status}: {payload}"
+                        )
+                        continue
+                    msg = f"API returned status {response.status}: {payload}"
+                    raise SvivaAirError(msg)
+            except (TimeoutError, ClientError) as exc:
+                last_error = exc
+                continue
+
+        raise SvivaAirError(str(last_error))
+
+    async def generate_token(self) -> str:
+        """Generate and store an API auth token."""
+        api_token_headers = self._headers()
+        api_token_headers["content-type"] = "application/json; charset=UTF-8"
+        api_token_headers["accept"] = "application/json, text/javascript, */*; q=0.01"
+        api_token = await self._request(
+            "POST",
+            GUEST_API_URL,
+            api_token_headers,
+            {"userName": "Guest"},
+        )
+
+        token_headers = self._headers()
+        token_headers["accept"] = "application/json"
+        token_headers["authorization"] = f"ApiToken {_clean_token(api_token)}"
+        self._auth_token = _clean_token(
+            await self._request("POST", AUTH_GENERATION_URL, token_headers, {})
+        )
+        self._auth_token_generated_at = time.time()
+        return self._auth_token
+
+    async def _ensure_auth_headers(self) -> dict[str, str]:
+        if self._auth_token is None or _jwt_expired(
+            self._auth_token,
+            self._auth_token_generated_at,
+        ):
+            await self.generate_token()
+        return self._headers()
+
+    async def _authorized_request(self, method: str, url: str) -> Any:
+        try:
+            return await self._request(
+                method,
+                url,
+                await self._ensure_auth_headers(),
+            )
+        except SvivaAirError as exc:
+            if "Unauthorized" not in str(exc):
+                raise
+            self._auth_token = None
+            return await self._request(
+                method,
+                url,
+                await self._ensure_auth_headers(),
+            )
+
+    async def get_regions(self) -> list[Region]:
+        """Get all monitoring regions with stations."""
+        response = await self._authorized_request(
+            "GET",
+            BASE_URL + "regions",
+        )
+        return [
+            Region(
+                region_id=region["regionId"],
+                name=region.get("name") or "",
+                stations=[
+                    _station_from_dict(station)
+                    for station in (region.get("stations") or [])
+                ],
+            )
+            for region in response
+        ]
+
+    async def get_regions_latest_data(
+        self,
+        region_ids: list[int],
+        hours_back: int = 4,
+    ) -> list[RegionStationData]:
+        """Get latest readings for the requested regions."""
+        ids = ",".join(str(region_id) for region_id in region_ids)
+        query = f"?unitConversion=true&regionsIds={ids}&hoursBack={hours_back}"
+        response = await self._authorized_request(
+            "GET",
+            BASE_URL + "regions/data/latest" + query,
+        )
+
+        stations: list[RegionStationData] = []
+        for item in response:
+            region_data = item.get("regionData") or {}
+            channels = [
+                _channel_from_dict(channel)
+                for channel in (region_data.get("channels") or [])
+            ]
+            stations.append(
+                RegionStationData(
+                    station_id=item["stationId"],
+                    region_data=RegionData(
+                        datetime=region_data.get("datetime"),
+                        channels=channels,
+                    ),
+                )
+            )
+        return stations

--- a/custom_components/air_sviva/config_flow.py
+++ b/custom_components/air_sviva/config_flow.py
@@ -6,11 +6,10 @@ import math
 from typing import TYPE_CHECKING
 
 import voluptuous as vol
-from air_sviva_api.client import SvivaAirClient
-from air_sviva_api.models.exceptions import SvivaAirError
 from homeassistant import config_entries
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
 
+from .api import SvivaAirClient, SvivaAirError
 from .const import (
     CONF_REGION_ID,
     CONF_STATION_ID,
@@ -20,7 +19,7 @@ from .const import (
 )
 
 if TYPE_CHECKING:
-    from air_sviva_api.models.region import Region, Station
+    from .api import Region, Station
 
 
 def _haversine_distance(lat1: float, lon1: float, lat2: float, lon2: float) -> float:

--- a/custom_components/air_sviva/coordinator.py
+++ b/custom_components/air_sviva/coordinator.py
@@ -115,7 +115,7 @@ class AirSvivaUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         index_response: list[StationIndexData] = []
         try:
             index_response = await client.get_stations_latest_index(
-                region_ids=all_regions,
+                region_ids=[self._region_id],
                 hours_back=24,
             )
         except SvivaAirError as exc:

--- a/custom_components/air_sviva/coordinator.py
+++ b/custom_components/air_sviva/coordinator.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
 
-    from .api import RegionStationData, SvivaAirClient
+    from .api import RegionStationData, StationIndexData, SvivaAirClient
     from .data import AirSvivaData
 
 
@@ -45,6 +45,27 @@ def _parse_station_channels(station_data: RegionStationData) -> dict[str, Any]:
         }
 
     return channels
+
+
+def _parse_station_index(
+    station_index: StationIndexData | None,
+) -> dict[str, Any] | None:
+    """Parse station index data into a dict for sensors."""
+    if station_index is None:
+        return None
+
+    return {
+        "datetime": station_index.datetime,
+        "pollutant": station_index.pollutant,
+        "index_id": station_index.index_id,
+        "index": station_index.index,
+        "value": station_index.value,
+        "color": station_index.color,
+        "description": station_index.description,
+        "pollutant_id": station_index.pollutant_id,
+        "pollutant_time_base": station_index.pollutant_time_base,
+        "indexes": station_index.indexes or [],
+    }
 
 
 class AirSvivaUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
@@ -91,7 +112,24 @@ class AirSvivaUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             msg = f"Unexpected error: {exc}"
             raise UpdateFailed(msg) from exc
 
-        data: dict[str, Any] = {"station_id": self._station_id, "channels": {}}
+        index_response: list[StationIndexData] = []
+        try:
+            index_response = await client.get_stations_latest_index(
+                region_ids=all_regions,
+                hours_back=24,
+            )
+        except SvivaAirError as exc:
+            LOGGER.warning(
+                "Failed to fetch official station index for %s: %s",
+                self._station_id,
+                exc,
+            )
+
+        data: dict[str, Any] = {
+            "station_id": self._station_id,
+            "channels": {},
+            "station_index": None,
+        }
 
         # Find the selected station in the response
         station_data = next(
@@ -106,6 +144,12 @@ class AirSvivaUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         # Parse all channels for this station
         data["channels"] = _parse_station_channels(station_data)
+
+        station_index = next(
+            (s for s in index_response if s.station_id == self._station_id),
+            None,
+        )
+        data["station_index"] = _parse_station_index(station_index)
 
         # Get the datetime from the first channel
         if station_data.region_data and station_data.region_data.channels:

--- a/custom_components/air_sviva/coordinator.py
+++ b/custom_components/air_sviva/coordinator.py
@@ -4,17 +4,16 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from air_sviva_api.models.exceptions import SvivaAirError
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
+from .api import SvivaAirError
 from .const import CONF_REGION_ID, CONF_STATION_ID, DOMAIN, LOGGER, SCAN_INTERVAL
 
 if TYPE_CHECKING:
-    from air_sviva_api.client import SvivaAirClient
-    from air_sviva_api.models.reading import RegionStationData
     from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
 
+    from .api import RegionStationData, SvivaAirClient
     from .data import AirSvivaData
 
 

--- a/custom_components/air_sviva/data.py
+++ b/custom_components/air_sviva/data.py
@@ -6,9 +6,10 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from air_sviva_api.client import SvivaAirClient
     from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
     from homeassistant.loader import Integration
+
+    from .api import SvivaAirClient
 
 
 @dataclass

--- a/custom_components/air_sviva/manifest.json
+++ b/custom_components/air_sviva/manifest.json
@@ -8,7 +8,7 @@
   "documentation": "https://github.com/GuyKh/air-sviva-custom-component",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/GuyKh/air-sviva-custom-component/issues",
-  "loggers": ["air_sviva", "air_sviva_api"],
-  "requirements": ["air-sviva-api==0.0.2"],
+  "loggers": ["air_sviva"],
+  "requirements": [],
   "version": "0.0.1"
 }

--- a/custom_components/air_sviva/sensor.py
+++ b/custom_components/air_sviva/sensor.py
@@ -10,6 +10,8 @@ from homeassistant.components.sensor import SensorEntity
 from .const import DOMAIN
 from .entity import AirSvivaEntity
 
+INDEX_SENSOR_KEY = "air_quality_index"
+
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
@@ -44,7 +46,14 @@ async def async_setup_entry(
 
     station_id = entry_data.station_id
 
-    async_add_entities(
+    entities: list[SensorEntity] = [
+        AirSvivaIndexSensor(
+            coordinator=coordinator,
+            entry_id=entry.entry_id,
+            station_id=station_id,
+        )
+    ]
+    entities.extend(
         AirSvivaSensor(
             coordinator=coordinator,
             entry_id=entry.entry_id,
@@ -57,6 +66,7 @@ async def async_setup_entry(
         )
         for pollutant, channel_data in data["channels"].items()
     )
+    async_add_entities(entities)
 
 
 class AirSvivaSensor(AirSvivaEntity, SensorEntity):
@@ -128,3 +138,49 @@ class AirSvivaSensor(AirSvivaEntity, SensorEntity):
             attrs["max_value"] = 360
             attrs["min_value"] = 0
         return attrs
+
+
+class AirSvivaIndexSensor(AirSvivaEntity, SensorEntity):
+    """Air Sviva official air quality index sensor."""
+
+    def __init__(
+        self,
+        coordinator: AirSvivaUpdateCoordinator,
+        entry_id: str,
+        station_id: int,
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator, entry_id, station_id)
+        self._attr_unique_id = f"sviva_station_{station_id}_{INDEX_SENSOR_KEY}"
+        self.entity_id = f"sensor.sviva_station_{station_id}_{INDEX_SENSOR_KEY}"
+        self._attr_translation_key = INDEX_SENSOR_KEY
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the current official air quality index value."""
+        data = self.coordinator.data
+        if data is None:
+            return None
+        station_index = data.get("station_index")
+        if station_index is None:
+            return None
+        return station_index.get("index")
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return extra state attributes."""
+        data = self.coordinator.data
+        if data is None:
+            return {}
+        station_index = data.get("station_index")
+        if station_index is None:
+            return {}
+        return {
+            "pollutant": station_index.get("pollutant"),
+            "pollutant_id": station_index.get("pollutant_id"),
+            "value": station_index.get("value"),
+            "description": station_index.get("description"),
+            "color": station_index.get("color"),
+            "datetime": station_index.get("datetime"),
+            "indexes": station_index.get("indexes", []),
+        }

--- a/custom_components/air_sviva/sensor.py
+++ b/custom_components/air_sviva/sensor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from math import isfinite
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.sensor import SensorEntity
@@ -11,6 +12,7 @@ from .const import DOMAIN
 from .entity import AirSvivaEntity
 
 INDEX_SENSOR_KEY = "air_quality_index"
+NORMALIZED_INDEX_SCALE = "uv_like_0_11"
 
 if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
@@ -29,6 +31,46 @@ class SensorInitData:
     station_name: str
     pollutant_name: str
     channel_data: dict[str, Any]
+
+
+def normalize_air_quality_index(index: Any) -> float | None:
+    """Normalize the official Air Sviva index to a UV-like risk scale."""
+    if index is None:
+        return None
+
+    try:
+        official_index = float(index)
+    except (TypeError, ValueError):
+        return None
+
+    if not isfinite(official_index):
+        return None
+
+    if official_index > 100:
+        return 0.0
+    if official_index >= 50:
+        normalized = _scale_index_range(official_index, 100, 50, 0.0, 2.9)
+    elif official_index >= -1:
+        normalized = _scale_index_range(official_index, 50, -1, 3.0, 5.9)
+    elif official_index >= -201:
+        normalized = _scale_index_range(official_index, -1, -201, 6.0, 7.9)
+    elif official_index >= -402:
+        normalized = _scale_index_range(official_index, -201, -402, 8.0, 11.0)
+    else:
+        return 11.0
+
+    return round(normalized, 1)
+
+
+def _scale_index_range(
+    value: float,
+    official_high: float,
+    official_low: float,
+    normalized_low: float,
+    normalized_high: float,
+) -> float:
+    ratio = (official_high - value) / (official_high - official_low)
+    return normalized_low + ratio * (normalized_high - normalized_low)
 
 
 async def async_setup_entry(
@@ -182,5 +224,7 @@ class AirSvivaIndexSensor(AirSvivaEntity, SensorEntity):
             "description": station_index.get("description"),
             "color": station_index.get("color"),
             "datetime": station_index.get("datetime"),
+            "normalized_index": normalize_air_quality_index(station_index.get("index")),
+            "normalized_index_scale": NORMALIZED_INDEX_SCALE,
             "indexes": station_index.get("indexes", []),
         }

--- a/custom_components/air_sviva/translations/en.json
+++ b/custom_components/air_sviva/translations/en.json
@@ -37,6 +37,7 @@
             "pm1": {"name": "PM1"},
             "pm4": {"name": "PM4"},
             "co": {"name": "CO"},
+            "air_quality_index": {"name": "Air Quality Index"},
             "co2": {"name": "CO₂"},
             "h2s": {"name": "H₂S"},
             "nh3": {"name": "NH₃"},

--- a/custom_components/air_sviva/translations/he.json
+++ b/custom_components/air_sviva/translations/he.json
@@ -31,6 +31,7 @@
             "pm1": { "name": "PM1" },
             "pm4": { "name": "PM4" },
             "co": { "name": "CO" },
+            "air_quality_index": { "name": "מדד איכות אוויר" },
             "co2": { "name": "CO₂" },
             "h2s": { "name": "H₂S" },
             "nh3": { "name": "NH₃" },


### PR DESCRIPTION
## Summary

Adds an official Air Sviva air quality index sensor for the selected station, using the public `stations/index/latest` endpoint.

Depends on #10. This branch is stacked on `fix/ha-core-api-dependency`, so the draft diff currently includes the dependency-loading fix until #10 is merged and this branch is rebased.

## Changes

- Fetch official station index data alongside the existing station pollutant data.
- Add `sensor.sviva_station_<station_id>_air_quality_index` with the official raw Air Sviva index as the sensor state.
- Preserve official metadata as attributes: pollutant, value, description, color, datetime, and per-pollutant index rows.
- Add `normalized_index` as a derived UV-like `0-11` attribute while keeping the official index state unchanged.
- Add English and Hebrew entity names.

## Validation

- `ruff check .`
- `ruff format . --check`
- `mypy . --no-error-summary`
- `python3 -m py_compile custom_components/air_sviva/*.py`
- `python3 -m json.tool` for strings and translation files
- Deployed on Home Assistant Core 2026.5.1 with station 414, confirmed:
  - `sensor.sviva_station_414_air_quality_index` state remains the official raw index.
  - `normalized_index` and `normalized_index_scale` attributes are present.
  - Existing pollutant sensors continue updating.