### PR TITLE
chore: set minimum HA version to 2026.5.0 in hacs.json

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,3 +1,4 @@
 {
-  "name": "Air Sviva"
+  "name": "Air Sviva",
+  "homeassistant": "2026.5.0"
 }


### PR DESCRIPTION
## Summary

Sets `"homeassistant": "2026.5.0"` in `hacs.json`, which was previously missing a minimum version field.

## Why

The `air-sviva-api` dependency (v0.0.2+) requires `orjson>=3.11.8`. Home Assistant Core first shipped `orjson==3.11.8` in the **2026.5.0** release. Earlier versions (2026.4.x and prior) ship `orjson==3.11.7` which would cause pip dependency resolution failures at install time.

Setting this minimum ensures HACS checks compatibility and warns users on older HA versions before installation, providing a clear error instead of a cryptic pip failure.

## Related

- Upstream fix: [py-air-sviva-api PR #11](https://github.com/GuyKh/py-air-sviva-api/pull/11) — relaxed `orjson>=3.11.9` → `>=3.11.8`