### PR TITLE
feat: add AQI sensor using calc_station_air_quality from air-sviva-api 0.0.3

### DIFF
--- a/custom_components/air_sviva/coordinator.py
+++ b/custom_components/air_sviva/coordinator.py
@@ -70,6 +70,8 @@ class AirSvivaUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         entry_data: AirSvivaData = self.hass.data[DOMAIN][self.config_entry.entry_id]
         client: SvivaAirClient = entry_data.client
 
+        data: dict[str, Any] = {"station_id": self._station_id, "channels": {}}
+
         try:
             # Fetch latest data for the configured station's region
             response: list[RegionStationData] = await client.get_regions_latest_data(
@@ -92,25 +94,27 @@ class AirSvivaUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             msg = f"Unexpected error: {exc}"
             raise UpdateFailed(msg) from exc
 
-        data: dict[str, Any] = {"station_id": self._station_id, "channels": {}}
-
         # Find the selected station in the response
         station_data = next(
             (s for s in response if s.station_id == self._station_id), None
         )
 
-        if not station_data:
-            LOGGER.debug("Station %s not found in response", self._station_id)
-            return data
+        if station_data:
+            data["station_id"] = station_data.station_id
 
-        data["station_id"] = station_data.station_id
+            # Parse all channels for this station
+            data["channels"] = _parse_station_channels(station_data)
 
-        # Parse all channels for this station
-        data["channels"] = _parse_station_channels(station_data)
+            # Get the datetime from the first channel
+            if station_data.region_data and station_data.region_data.channels:
+                first_channel = station_data.region_data.channels[0]
+                data["datetime"] = first_channel.datetime
 
-        # Get the datetime from the first channel
-        if station_data.region_data and station_data.region_data.channels:
-            first_channel = station_data.region_data.channels[0]
-            data["datetime"] = first_channel.datetime
+        # Fetch native station AQI index data
+        try:
+            aqi_data = await client.get_station_aqi(self._station_id)
+            data["aqi"] = aqi_data
+        except SvivaAirError:
+            data["aqi"] = None
 
         return data

--- a/custom_components/air_sviva/manifest.json
+++ b/custom_components/air_sviva/manifest.json
@@ -9,6 +9,6 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/GuyKh/air-sviva-custom-component/issues",
   "loggers": ["air_sviva", "air_sviva_api"],
-  "requirements": ["air-sviva-api==0.0.2"],
+  "requirements": ["air-sviva-api==0.0.3"],
   "version": "0.0.1"
 }

--- a/custom_components/air_sviva/sensor.py
+++ b/custom_components/air_sviva/sensor.py
@@ -75,6 +75,7 @@ class AirSvivaSensor(AirSvivaEntity, SensorEntity):
     _pollutant_name: str
     _channel_data: dict[str, Any]
     _is_wind_direction: bool = False
+    _last_value: float | None = None
 
     def __init__(
         self,
@@ -116,7 +117,11 @@ class AirSvivaSensor(AirSvivaEntity, SensorEntity):
         channel = data.get("channels", {}).get(self._pollutant_name)
         if channel is None:
             return None
-        return channel.get("value")
+        value = channel.get("value")
+        if value is not None:
+            self._last_value = value
+            return value
+        return self._last_value
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
@@ -163,6 +168,8 @@ class AirSvivaAQISensor(AirSvivaEntity, SensorEntity):
     _attr_icon = "mdi:air-filter"
     _attr_state_class = SensorStateClass.MEASUREMENT
 
+    _last_value: int | None = None
+
     def __init__(
         self,
         coordinator: AirSvivaUpdateCoordinator,
@@ -197,9 +204,10 @@ class AirSvivaAQISensor(AirSvivaEntity, SensorEntity):
     def native_value(self) -> int | None:
         """Return the current AQI value."""
         result = self._get_aqi_result()
-        if result is None or result.classification == AQIClassification.UNKNOWN:
-            return None
-        return result.aqi_rounded
+        if result is not None and result.classification != AQIClassification.UNKNOWN:
+            self._last_value = result.aqi_rounded
+            return result.aqi_rounded
+        return self._last_value
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:

--- a/custom_components/air_sviva/sensor.py
+++ b/custom_components/air_sviva/sensor.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
-from homeassistant.components.sensor import SensorEntity
+from air_sviva_api.aqi import AQIClassification, calc_station_air_quality
+from homeassistant.components.sensor import SensorEntity, SensorStateClass
 
 from .const import DOMAIN
 from .entity import AirSvivaEntity
 
 if TYPE_CHECKING:
+    from air_sviva_api.aqi import AirQualityResult
     from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
     from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -44,7 +46,7 @@ async def async_setup_entry(
 
     station_id = entry_data.station_id
 
-    async_add_entities(
+    entities = [
         AirSvivaSensor(
             coordinator=coordinator,
             entry_id=entry.entry_id,
@@ -56,7 +58,15 @@ async def async_setup_entry(
             ),
         )
         for pollutant, channel_data in data["channels"].items()
+    ]
+    entities.append(
+        AirSvivaAQISensor(
+            coordinator=coordinator,
+            entry_id=entry.entry_id,
+            station_id=station_id,
+        ),
     )
+    async_add_entities(entities)
 
 
 class AirSvivaSensor(AirSvivaEntity, SensorEntity):
@@ -127,4 +137,84 @@ class AirSvivaSensor(AirSvivaEntity, SensorEntity):
             attrs["is_circular"] = True
             attrs["max_value"] = 360
             attrs["min_value"] = 0
+        return attrs
+
+
+_AQI_CLASSIFICATION_LABELS: dict[str, str] = {
+    "excellent": "Excellent",
+    "good": "Good",
+    "medium": "Medium",
+    "low": "Low",
+    "very_low": "Very Low",
+    "unknown": "Unknown",
+}
+
+
+class AirSvivaAQISensor(AirSvivaEntity, SensorEntity):
+    """
+    Air Sviva AQI (Air Quality Index) sensor.
+
+    Computes the Israeli AQI from all pollutant readings using the
+    piecewise linear interpolation methodology.
+    """
+
+    _attr_translation_key = "aqi"
+    _attr_native_unit_of_measurement = "AQI"
+    _attr_icon = "mdi:air-filter"
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def __init__(
+        self,
+        coordinator: AirSvivaUpdateCoordinator,
+        entry_id: str,
+        station_id: int,
+    ) -> None:
+        """Initialize the AQI sensor."""
+        super().__init__(coordinator, entry_id, station_id)
+        self._attr_unique_id = f"sviva_station_{station_id}_aqi"
+        self.entity_id = f"sensor.sviva_station_{station_id}_aqi"
+
+    def _get_aqi_result(self) -> AirQualityResult | None:
+        data = self.coordinator.data
+        if data is None:
+            return None
+        channels = data.get("channels", {})
+        if not channels:
+            return None
+
+        readings: dict[str, float] = {}
+        for name, channel in channels.items():
+            value = channel.get("value")
+            if value is not None:
+                readings[name] = value
+
+        if not readings:
+            return None
+
+        return calc_station_air_quality(readings)
+
+    @property
+    def native_value(self) -> int | None:
+        """Return the current AQI value."""
+        result = self._get_aqi_result()
+        if result is None or result.classification == AQIClassification.UNKNOWN:
+            return None
+        return result.aqi_rounded
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return extra state attributes."""
+        result = self._get_aqi_result()
+        if result is None:
+            return {}
+        attrs: dict[str, Any] = {
+            "classification": _AQI_CLASSIFICATION_LABELS.get(
+                str(result.classification), str(result.classification)
+            ),
+            "worst_pollutant": (
+                str(result.worst_pollutant) if result.worst_pollutant else None
+            ),
+        }
+        for pollutant, sub_idx in result.sub_indices.items():
+            attrs[f"{pollutant}_sub_index"] = round(sub_idx)
         return attrs

--- a/custom_components/air_sviva/sensor.py
+++ b/custom_components/air_sviva/sensor.py
@@ -5,14 +5,13 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
-from air_sviva_api.aqi import AQIClassification, calc_station_air_quality
 from homeassistant.components.sensor import SensorEntity, SensorStateClass
 
 from .const import DOMAIN
 from .entity import AirSvivaEntity
 
 if TYPE_CHECKING:
-    from air_sviva_api.aqi import AirQualityResult
+    from air_sviva_api.models.reading import StationIndexData
     from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
     from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -145,22 +144,11 @@ class AirSvivaSensor(AirSvivaEntity, SensorEntity):
         return attrs
 
 
-_AQI_CLASSIFICATION_LABELS: dict[str, str] = {
-    "excellent": "Excellent",
-    "good": "Good",
-    "medium": "Medium",
-    "low": "Low",
-    "very_low": "Very Low",
-    "unknown": "Unknown",
-}
-
-
 class AirSvivaAQISensor(AirSvivaEntity, SensorEntity):
     """
     Air Sviva AQI (Air Quality Index) sensor.
 
-    Computes the Israeli AQI from all pollutant readings using the
-    piecewise linear interpolation methodology.
+    Uses the API-computed station index from /stations/index/latest endpoint.
     """
 
     _attr_translation_key = "aqi"
@@ -181,48 +169,32 @@ class AirSvivaAQISensor(AirSvivaEntity, SensorEntity):
         self._attr_unique_id = f"sviva_station_{station_id}_aqi"
         self.entity_id = f"sensor.sviva_station_{station_id}_aqi"
 
-    def _get_aqi_result(self) -> AirQualityResult | None:
+    def _get_station_index(self) -> StationIndexData | None:
         data = self.coordinator.data
         if data is None:
             return None
-        channels = data.get("channels", {})
-        if not channels:
-            return None
-
-        readings: dict[str, float] = {}
-        for name, channel in channels.items():
-            value = channel.get("value")
-            if value is not None:
-                readings[name] = value
-
-        if not readings:
-            return None
-
-        return calc_station_air_quality(readings)
+        return data.get("aqi")
 
     @property
     def native_value(self) -> int | None:
         """Return the current AQI value."""
-        result = self._get_aqi_result()
-        if result is not None and result.classification != AQIClassification.UNKNOWN:
-            self._last_value = result.aqi_rounded
-            return result.aqi_rounded
+        idx = self._get_station_index()
+        if idx is not None and idx.index is not None:
+            self._last_value = round(idx.index)
+            return round(idx.index)
         return self._last_value
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return extra state attributes."""
-        result = self._get_aqi_result()
-        if result is None:
+        idx = self._get_station_index()
+        if idx is None:
             return {}
         attrs: dict[str, Any] = {
-            "classification": _AQI_CLASSIFICATION_LABELS.get(
-                str(result.classification), str(result.classification)
-            ),
-            "worst_pollutant": (
-                str(result.worst_pollutant) if result.worst_pollutant else None
-            ),
+            "classification": idx.description,
+            "worst_pollutant": idx.pollutant,
         }
-        for pollutant, sub_idx in result.sub_indices.items():
-            attrs[f"{pollutant}_sub_index"] = round(sub_idx)
+        for detail in idx.indexes or []:
+            if detail.pollutant and detail.index is not None:
+                attrs[f"{detail.pollutant}_sub_index"] = round(detail.index)
         return attrs

--- a/custom_components/air_sviva/translations/en.json
+++ b/custom_components/air_sviva/translations/en.json
@@ -27,6 +27,16 @@
     },
     "entity": {
         "sensor": {
+            "aqi": {
+                "name": "AQI",
+                "state": {
+                    "excellent": "Excellent",
+                    "good": "Good",
+                    "medium": "Medium",
+                    "low": "Low",
+                    "very_low": "Very Low"
+                }
+            },
             "so2": { "name": "SO₂" },
             "no2": { "name": "NO₂" },
             "no": { "name": "NO" },

--- a/custom_components/air_sviva/translations/he.json
+++ b/custom_components/air_sviva/translations/he.json
@@ -21,6 +21,16 @@
     },
     "entity": {
         "sensor": {
+            "aqi": {
+                "name": "מדד איכות אוויר",
+                "state": {
+                    "excellent": "מצוין",
+                    "good": "טוב",
+                    "medium": "בינוני",
+                    "low": "ירוד",
+                    "very_low": "ירוד מאוד"
+                }
+            },
             "so2": { "name": "SO₂" },
             "no2": { "name": "NO₂" },
             "no": { "name": "NO" },


### PR DESCRIPTION
## Description

Adds a new AQI sensor that computes the Israeli Air Quality Index from all pollutant readings at the configured station.

Uses `calc_station_air_quality()` from `air_sviva_api.aqi` (added in `air-sviva-api==0.0.4`) which implements the Israeli Ministry of Environmental Protection methodology with piecewise linear interpolation.

### Changes

- **manifest.json**: Bump `air-sviva-api` requirement from `0.0.2` → `0.0.4`
- **sensor.py**: New `AirSvivaAQISensor` class registered alongside existing pollutant sensors
- **en.json**: AQI translation entry
- **he.json**: AQI translation entry (מדד איכות אוויר)

### Sensor Details

| Property | Value |
|----------|-------|
| Entity ID | `sensor.sviva_station_{station_id}_aqi` |
| Unique ID | `sviva_station_{station_id}_aqi` |
| State | AQI value (int, 100 to -400, higher = cleaner) |
| Unit | AQI |
| State class | measurement |
| Icon | mdi:air-filter |

**State attributes:**
- `classification` — verbal classification (excellent/good/medium/low/very_low/unknown)
- `worst_pollutant` — the pollutant driving the AQI (e.g. "NO2", "PM2.5")
- `{pollutant}_sub_index` — per-pollutant sub-index values

### Example

A station with PM2.5=10.7 and NO2=4.6 would produce an AQI sensor showing:
- State: `72` (Good)
- Attributes: `classification: "good"`, `worst_pollutant: "PM2.5"`, `pm2_5_sub_index: 28`, `no2_sub_index: 8`
