### PR TITLE
feat: include city name in station selection labels

### DIFF
--- a/custom_components/air_sviva/config_flow.py
+++ b/custom_components/air_sviva/config_flow.py
@@ -166,11 +166,7 @@ class AirSvivaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ign
         station_options = {}
         for station in active_stations:
             pollutants = _get_station_pollutants(station)
-            label = (
-                f"{station.name}, {station.city}"
-                if station.city
-                else station.name
-            )
+            label = f"{station.name}, {station.city}" if station.city else station.name
             if pollutants:
                 label = f"{label} - {pollutants}"
             station_options[station.station_id] = label

--- a/custom_components/air_sviva/config_flow.py
+++ b/custom_components/air_sviva/config_flow.py
@@ -166,9 +166,13 @@ class AirSvivaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ign
         station_options = {}
         for station in active_stations:
             pollutants = _get_station_pollutants(station)
-            label = station.name
+            label = (
+                f"{station.name}, {station.city}"
+                if station.city
+                else station.name
+            )
             if pollutants:
-                label = f"{station.name} - {pollutants}"
+                label = f"{label} - {pollutants}"
             station_options[station.station_id] = label
 
         return self.async_show_form(


### PR DESCRIPTION
## Description

Modifies the station selection dropdown in the config flow to include both the station name and its city, formatted as **"station name, city"** instead of just the station name.

**Before:** `תחנת רכבת סבידור`
**After:** `תחנת רכבת סבידור, תל אביב-יפו`

Falls back to station name only when city data is unavailable (some stations may not have a city value).

## Change

- `custom_components/air_sviva/config_flow.py` — Updated station label formatting in `async_step_select_station`