### PR TITLE
feat: share auth client across config entries

### DIFF
--- a/custom_components/air_sviva/__init__.py
+++ b/custom_components/air_sviva/__init__.py
@@ -14,6 +14,7 @@ from .const import (
     CONF_STATION_NAME,
     DOMAIN,
     PLATFORMS,
+    SHARED_CLIENT_KEY,
 )
 from .coordinator import AirSvivaUpdateCoordinator
 from .data import AirSvivaData
@@ -28,13 +29,18 @@ async def async_setup_entry(
     entry: ConfigEntry,
 ) -> bool:
     """Set up the Air Sviva integration from a config entry."""
-    client = SvivaAirClient(session=async_get_clientsession(hass))
-    await client.generate_token()
+    hass.data.setdefault(DOMAIN, {})
+
+    shared_client: SvivaAirClient | None = hass.data[DOMAIN].get(SHARED_CLIENT_KEY)
+    if shared_client is None:
+        shared_client = SvivaAirClient(session=async_get_clientsession(hass))
+        await shared_client.generate_token()
+        hass.data[DOMAIN][SHARED_CLIENT_KEY] = shared_client
 
     coordinator = AirSvivaUpdateCoordinator(hass=hass, config_entry=entry)
 
     entry_data = AirSvivaData(
-        client=client,
+        client=shared_client,
         integration=async_get_loaded_integration(hass, entry.domain),
         coordinator=coordinator,
         region_id=entry.data[CONF_REGION_ID],
@@ -42,7 +48,7 @@ async def async_setup_entry(
         station_name=entry.data[CONF_STATION_NAME],
     )
 
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = entry_data
+    hass.data[DOMAIN][entry.entry_id] = entry_data
 
     await coordinator.async_config_entry_first_refresh()
 
@@ -60,6 +66,9 @@ async def async_unload_entry(
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id)
+        entry_keys = [k for k in hass.data[DOMAIN] if k != SHARED_CLIENT_KEY]
+        if not entry_keys:
+            hass.data[DOMAIN].pop(SHARED_CLIENT_KEY, None)
     return unload_ok
 
 

--- a/custom_components/air_sviva/const.py
+++ b/custom_components/air_sviva/const.py
@@ -18,3 +18,5 @@ SCAN_INTERVAL = timedelta(minutes=10)
 DEFAULT_HOURS_BACK = 4
 
 PLATFORMS: list[Platform] = [Platform.SENSOR]
+
+SHARED_CLIENT_KEY: str = f"{DOMAIN}_shared_client"


### PR DESCRIPTION
## Description

Previously, each config entry (station) created its own `SvivaAirClient` and generated its own auth token. When adding multiple stations, this meant:
- Redundant HTTP calls for token generation
- Multiple auth tokens for the same integration

Now, all config entries share a single `SvivaAirClient` instance stored at `hass.data[DOMAIN]["air_sviva_shared_client"]`. The client is created on first entry setup and cleaned up when the last entry is removed.

## Changes

- `custom_components/air_sviva/const.py` — Added `SHARED_CLIENT_KEY` constant for the shared client storage key
- `custom_components/air_sviva/__init__.py` — 
  - `async_setup_entry`: Reuses existing shared client or creates one on first entry
  - `async_unload_entry`: Cleans up the shared client when the last entry is removed

## Backwards compatibility

Fully backwards compatible. Existing single-entry installations are unaffected. The shared client is transparent — all existing code paths that access `entry_data.client` continue to work unchanged.