### PR TITLE
feat: add station device details to sensor attributes

### DIFF
--- a/custom_components/air_sviva/__init__.py
+++ b/custom_components/air_sviva/__init__.py
@@ -10,8 +10,16 @@ from homeassistant.loader import async_get_loaded_integration
 
 from .const import (
     CONF_REGION_ID,
+    CONF_STATION_ADDRESS,
+    CONF_STATION_CITY,
+    CONF_STATION_HEIGHT,
     CONF_STATION_ID,
+    CONF_STATION_LATITUDE,
+    CONF_STATION_LONGITUDE,
     CONF_STATION_NAME,
+    CONF_STATION_OWNER,
+    CONF_STATION_REGION_NAME,
+    CONF_STATION_TARGET,
     DOMAIN,
     PLATFORMS,
     SHARED_CLIENT_KEY,
@@ -46,6 +54,14 @@ async def async_setup_entry(
         region_id=entry.data[CONF_REGION_ID],
         station_id=entry.data[CONF_STATION_ID],
         station_name=entry.data[CONF_STATION_NAME],
+        station_city=entry.data.get(CONF_STATION_CITY),
+        station_address=entry.data.get(CONF_STATION_ADDRESS),
+        station_owner=entry.data.get(CONF_STATION_OWNER),
+        station_target=entry.data.get(CONF_STATION_TARGET),
+        station_height=entry.data.get(CONF_STATION_HEIGHT),
+        station_latitude=entry.data.get(CONF_STATION_LATITUDE),
+        station_longitude=entry.data.get(CONF_STATION_LONGITUDE),
+        station_region_name=entry.data.get(CONF_STATION_REGION_NAME),
     )
 
     hass.data[DOMAIN][entry.entry_id] = entry_data

--- a/custom_components/air_sviva/config_flow.py
+++ b/custom_components/air_sviva/config_flow.py
@@ -13,8 +13,16 @@ from homeassistant.helpers.aiohttp_client import async_create_clientsession
 
 from .const import (
     CONF_REGION_ID,
+    CONF_STATION_ADDRESS,
+    CONF_STATION_CITY,
+    CONF_STATION_HEIGHT,
     CONF_STATION_ID,
+    CONF_STATION_LATITUDE,
+    CONF_STATION_LONGITUDE,
     CONF_STATION_NAME,
+    CONF_STATION_OWNER,
+    CONF_STATION_REGION_NAME,
+    CONF_STATION_TARGET,
     DOMAIN,
     LOGGER,
 )
@@ -142,12 +150,36 @@ class AirSvivaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ign
             )
             if selected_station:
                 LOGGER.debug("Selected station: %s", selected_station.name)
+
+                region_name = next(
+                    (
+                        r.name
+                        for r in self._regions or []
+                        if r.region_id == self._selected_region_id
+                    ),
+                    None,
+                )
+
+                station_lat = None
+                station_lon = None
+                if selected_station.location:
+                    station_lat = selected_station.location.latitude
+                    station_lon = selected_station.location.longitude
+
                 return self.async_create_entry(
                     title=f"Air Sviva - {selected_station.name}",
                     data={
                         CONF_REGION_ID: self._selected_region_id,
                         CONF_STATION_ID: station_id,
                         CONF_STATION_NAME: selected_station.name,
+                        CONF_STATION_CITY: selected_station.city,
+                        CONF_STATION_ADDRESS: selected_station.address,
+                        CONF_STATION_OWNER: selected_station.owner,
+                        CONF_STATION_TARGET: selected_station.station_target,
+                        CONF_STATION_HEIGHT: selected_station.height,
+                        CONF_STATION_LATITUDE: station_lat,
+                        CONF_STATION_LONGITUDE: station_lon,
+                        CONF_STATION_REGION_NAME: region_name,
                     },
                 )
             LOGGER.error(

--- a/custom_components/air_sviva/const.py
+++ b/custom_components/air_sviva/const.py
@@ -13,6 +13,14 @@ ATTRIBUTION = "Data provided by the Israeli Ministry of Environmental Protection
 CONF_REGION_ID = "region_id"
 CONF_STATION_ID = "station_id"
 CONF_STATION_NAME = "station_name"
+CONF_STATION_CITY = "station_city"
+CONF_STATION_ADDRESS = "station_address"
+CONF_STATION_OWNER = "station_owner"
+CONF_STATION_TARGET = "station_target"
+CONF_STATION_HEIGHT = "station_height"
+CONF_STATION_LATITUDE = "station_latitude"
+CONF_STATION_LONGITUDE = "station_longitude"
+CONF_STATION_REGION_NAME = "station_region_name"
 
 SCAN_INTERVAL = timedelta(minutes=10)
 DEFAULT_HOURS_BACK = 4

--- a/custom_components/air_sviva/data.py
+++ b/custom_components/air_sviva/data.py
@@ -21,3 +21,11 @@ class AirSvivaData:
     region_id: int
     station_id: int
     station_name: str
+    station_city: str | None = None
+    station_address: str | None = None
+    station_owner: str | None = None
+    station_target: str | None = None
+    station_height: str | None = None
+    station_latitude: float | None = None
+    station_longitude: float | None = None
+    station_region_name: str | None = None

--- a/custom_components/air_sviva/entity.py
+++ b/custom_components/air_sviva/entity.py
@@ -2,11 +2,16 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, Any
+
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import ATTRIBUTION, DOMAIN
 from .coordinator import AirSvivaUpdateCoordinator
+
+if TYPE_CHECKING:
+    from .data import AirSvivaData
 
 
 class AirSvivaEntity(CoordinatorEntity[AirSvivaUpdateCoordinator]):
@@ -24,10 +29,39 @@ class AirSvivaEntity(CoordinatorEntity[AirSvivaUpdateCoordinator]):
         """Initialize the entity."""
         super().__init__(coordinator)
         self._entry_id = entry_id
+        self._station_id = station_id
+
+        entry_data: AirSvivaData = coordinator.hass.data[DOMAIN][entry_id]
+
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, entry_id)},
-            name=f"Air Sviva Station {station_id}",
+            name=entry_data.station_name or f"Air Sviva Station {station_id}",
             manufacturer="Israeli Ministry of Environmental Protection",
             model="Air Quality Monitor",
             serial_number=str(station_id),
         )
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return extra state attributes with station metadata."""
+        entry_data: AirSvivaData = self.coordinator.hass.data[DOMAIN][self._entry_id]
+        attrs: dict[str, Any] = {}
+
+        if entry_data.station_city:
+            attrs["city"] = entry_data.station_city
+        if entry_data.station_address:
+            attrs["address"] = entry_data.station_address
+        if entry_data.station_owner:
+            attrs["owner"] = entry_data.station_owner
+        if entry_data.station_target:
+            attrs["station_type"] = entry_data.station_target
+        if entry_data.station_region_name:
+            attrs["region"] = entry_data.station_region_name
+        if entry_data.station_height:
+            attrs["altitude"] = entry_data.station_height
+        if entry_data.station_latitude is not None:
+            attrs["latitude"] = entry_data.station_latitude
+        if entry_data.station_longitude is not None:
+            attrs["longitude"] = entry_data.station_longitude
+
+        return attrs

--- a/custom_components/air_sviva/sensor.py
+++ b/custom_components/air_sviva/sensor.py
@@ -129,14 +129,17 @@ class AirSvivaSensor(AirSvivaEntity, SensorEntity):
         if data is None:
             return {}
         channel = data.get("channels", {}).get(self._pollutant_name, {})
-        attrs: dict[str, Any] = {
-            "channel_id": channel.get("id"),
-            "pollutant_id": channel.get("pollutant_id"),
-            "color": channel.get("color"),
-            "description": channel.get("description"),
-            "alias": channel.get("alias"),
-            "datetime": channel.get("datetime"),
-        }
+        attrs: dict[str, Any] = dict(super().extra_state_attributes or {})
+        attrs.update(
+            {
+                "channel_id": channel.get("id"),
+                "pollutant_id": channel.get("pollutant_id"),
+                "color": channel.get("color"),
+                "description": channel.get("description"),
+                "alias": channel.get("alias"),
+                "datetime": channel.get("datetime"),
+            }
+        )
         if self._is_wind_direction:
             attrs["is_circular"] = True
             attrs["max_value"] = 360
@@ -188,12 +191,15 @@ class AirSvivaAQISensor(AirSvivaEntity, SensorEntity):
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return extra state attributes."""
         idx = self._get_station_index()
+        attrs: dict[str, Any] = dict(super().extra_state_attributes or {})
         if idx is None:
-            return {}
-        attrs: dict[str, Any] = {
-            "classification": idx.description,
-            "worst_pollutant": idx.pollutant,
-        }
+            return attrs
+        attrs.update(
+            {
+                "classification": idx.description,
+                "worst_pollutant": idx.pollutant,
+            }
+        )
         for detail in idx.indexes or []:
             if detail.pollutant and detail.index is not None:
                 attrs[f"{detail.pollutant}_sub_index"] = round(detail.index)


### PR DESCRIPTION
## Summary
- Store station metadata (city, address, owner, station type, height, coordinates, region name) during config flow
- Expose station details as `extra_state_attributes` on all sensor entities
- Improve device name to use actual station name
- Backward compatible — existing entries use `.get()` defaults

## Details
Station details sourced from the `/v1/envista/regions` API endpoint at config time, stored in config entry data, and passed through `AirSvivaData` to the base entity.

All sensors (pollutant + AQI) now expose: `city`, `address`, `owner`, `station_type`, `region`, `altitude`, `latitude`, `longitude` attributes.

## Test Plan
- [ ] Ruff + mypy validation passes
- [ ] Existing entries continue working (new fields optional via `.get()`)
- [ ] New configuration stores full station metadata