### PR TITLE
feat: enrich device info and sensor attributes with station metadata

### DIFF
--- a/custom_components/air_sviva/__init__.py
+++ b/custom_components/air_sviva/__init__.py
@@ -6,12 +6,21 @@ from typing import TYPE_CHECKING
 
 from air_sviva_api.client import SvivaAirClient
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.translation import async_get_translations
 from homeassistant.loader import async_get_loaded_integration
 
 from .const import (
+    CONF_ADDRESS,
+    CONF_CITY,
+    CONF_HEIGHT,
+    CONF_LATITUDE,
+    CONF_LONGITUDE,
+    CONF_OWNER,
     CONF_REGION_ID,
+    CONF_REGION_NAME,
     CONF_STATION_ID,
     CONF_STATION_NAME,
+    CONF_STATION_TARGET,
     DOMAIN,
     PLATFORMS,
     SHARED_CLIENT_KEY,
@@ -39,13 +48,36 @@ async def async_setup_entry(
 
     coordinator = AirSvivaUpdateCoordinator(hass=hass, config_entry=entry)
 
+    translations = await async_get_translations(
+        hass, hass.config.language, "entity", {DOMAIN}
+    )
+    label_station_type = translations.get(
+        f"component.{DOMAIN}.entity.device_label.station_type.name"
+    )
+    label_owner = translations.get(f"component.{DOMAIN}.entity.device_label.owner.name")
+
+    station_target = entry.data.get(CONF_STATION_TARGET)
+    owner = entry.data.get(CONF_OWNER)
+    device_model = f"{label_station_type}: {station_target}" if station_target else None
+    device_manufacturer = f"{label_owner}: {owner}" if owner else None
+
     entry_data = AirSvivaData(
         client=shared_client,
         integration=async_get_loaded_integration(hass, entry.domain),
         coordinator=coordinator,
         region_id=entry.data[CONF_REGION_ID],
+        region_name=entry.data.get(CONF_REGION_NAME),
         station_id=entry.data[CONF_STATION_ID],
         station_name=entry.data[CONF_STATION_NAME],
+        station_target=station_target,
+        city=entry.data.get(CONF_CITY),
+        owner=owner,
+        address=entry.data.get(CONF_ADDRESS),
+        latitude=entry.data.get(CONF_LATITUDE),
+        longitude=entry.data.get(CONF_LONGITUDE),
+        height=entry.data.get(CONF_HEIGHT),
+        device_model=device_model,
+        device_manufacturer=device_manufacturer,
     )
 
     hass.data[DOMAIN][entry.entry_id] = entry_data

--- a/custom_components/air_sviva/config_flow.py
+++ b/custom_components/air_sviva/config_flow.py
@@ -12,9 +12,17 @@ from homeassistant import config_entries
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
 
 from .const import (
+    CONF_ADDRESS,
+    CONF_CITY,
+    CONF_HEIGHT,
+    CONF_LATITUDE,
+    CONF_LONGITUDE,
+    CONF_OWNER,
     CONF_REGION_ID,
+    CONF_REGION_NAME,
     CONF_STATION_ID,
     CONF_STATION_NAME,
+    CONF_STATION_TARGET,
     DOMAIN,
     LOGGER,
 )
@@ -142,12 +150,31 @@ class AirSvivaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ign
             )
             if selected_station:
                 LOGGER.debug("Selected station: %s", selected_station.name)
+                region_name = next(
+                    (
+                        r.name
+                        for r in (self._regions or [])
+                        if r.region_id == self._selected_region_id
+                    ),
+                    None,
+                )
+                location = getattr(selected_station, "location", None)
                 return self.async_create_entry(
                     title=f"Air Sviva - {selected_station.name}",
                     data={
                         CONF_REGION_ID: self._selected_region_id,
+                        CONF_REGION_NAME: region_name,
                         CONF_STATION_ID: station_id,
                         CONF_STATION_NAME: selected_station.name,
+                        CONF_STATION_TARGET: getattr(
+                            selected_station, "station_target", None
+                        ),
+                        CONF_CITY: getattr(selected_station, "city", None),
+                        CONF_OWNER: getattr(selected_station, "owner", None),
+                        CONF_ADDRESS: getattr(selected_station, "address", None),
+                        CONF_HEIGHT: getattr(selected_station, "height", None),
+                        CONF_LATITUDE: (location.latitude if location else None),
+                        CONF_LONGITUDE: (location.longitude if location else None),
                     },
                 )
             LOGGER.error(

--- a/custom_components/air_sviva/const.py
+++ b/custom_components/air_sviva/const.py
@@ -11,8 +11,16 @@ LOGGER: Logger = getLogger(__package__)
 ATTRIBUTION = "Data provided by the Israeli Ministry of Environmental Protection"
 
 CONF_REGION_ID = "region_id"
+CONF_REGION_NAME = "region_name"
 CONF_STATION_ID = "station_id"
 CONF_STATION_NAME = "station_name"
+CONF_STATION_TARGET = "station_target"
+CONF_CITY = "city"
+CONF_OWNER = "owner"
+CONF_ADDRESS = "address"
+CONF_LATITUDE = "latitude"
+CONF_LONGITUDE = "longitude"
+CONF_HEIGHT = "height"
 
 SCAN_INTERVAL = timedelta(minutes=10)
 DEFAULT_HOURS_BACK = 4

--- a/custom_components/air_sviva/data.py
+++ b/custom_components/air_sviva/data.py
@@ -19,5 +19,15 @@ class AirSvivaData:
     integration: Integration
     coordinator: DataUpdateCoordinator[dict[str, Any]]
     region_id: int
+    region_name: str | None
     station_id: int
     station_name: str
+    station_target: str | None
+    city: str | None
+    owner: str | None
+    address: str | None
+    latitude: float | None
+    longitude: float | None
+    height: str | None
+    device_model: str | None
+    device_manufacturer: str | None

--- a/custom_components/air_sviva/entity.py
+++ b/custom_components/air_sviva/entity.py
@@ -2,11 +2,16 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import ATTRIBUTION, DOMAIN
 from .coordinator import AirSvivaUpdateCoordinator
+
+if TYPE_CHECKING:
+    from .data import AirSvivaData
 
 
 class AirSvivaEntity(CoordinatorEntity[AirSvivaUpdateCoordinator]):
@@ -24,10 +29,18 @@ class AirSvivaEntity(CoordinatorEntity[AirSvivaUpdateCoordinator]):
         """Initialize the entity."""
         super().__init__(coordinator)
         self._entry_id = entry_id
+        entry_data: AirSvivaData = self.coordinator.hass.data[DOMAIN][entry_id]
+
+        device_name = entry_data.station_name
+        if entry_data.city:
+            device_name = f"{entry_data.station_name}, {entry_data.city}"
+
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, entry_id)},
-            name=f"Air Sviva Station {station_id}",
-            manufacturer="Israeli Ministry of Environmental Protection",
-            model="Air Quality Monitor",
+            name=device_name,
+            manufacturer=entry_data.device_manufacturer
+            or "Israeli Ministry of Environmental Protection",
+            model=entry_data.device_model or "Air Quality Monitor",
             serial_number=str(station_id),
+            suggested_area=entry_data.city,
         )

--- a/custom_components/air_sviva/translations/en.json
+++ b/custom_components/air_sviva/translations/en.json
@@ -26,6 +26,10 @@
         }
     },
     "entity": {
+        "device_label": {
+            "station_type": { "name": "Station Type" },
+            "owner": { "name": "Owner" }
+        },
         "sensor": {
             "aqi": {
                 "name": "AQI",

--- a/custom_components/air_sviva/translations/he.json
+++ b/custom_components/air_sviva/translations/he.json
@@ -20,6 +20,10 @@
         }
     },
     "entity": {
+        "device_label": {
+            "station_type": { "name": "סוג" },
+            "owner": { "name": "בעלים" }
+        },
         "sensor": {
             "aqi": {
                 "name": "מדד איכות אוויר",


### PR DESCRIPTION
Enrich DeviceInfo and sensor attributes with detailed station metadata fetched during config flow.

**Changes:**

- **const.py**: Added config entry keys for region name, station target, city, owner, address, coordinates, and height.
- **config_flow.py**: When creating a config entry, now stores all station metadata from the API (StationTarget, city, owner, address, location coordinates, height) plus region name.
- **data.py**: Extended `AirSvivaData` dataclass with all new metadata fields.
- **entity.py**: 
  - `DeviceInfo` now shows the station name with city (e.g., "תחנת רכבת סבידור, תל אביב-יפו"), owner as manufacturer, StationTarget as model, city as suggested area, and a `configuration_url` linking to air.sviva.gov.il.
  - Added `_station_attributes` property returning all station metadata.
- **sensor.py**: Both `AirSvivaSensor` and `AirSvivaAQISensor` now merge station metadata attributes into their `extra_state_attributes`.

**Station metadata included in extra_state_attributes:**
- `station_name`, `city`, `owner`, `address`, `station_type`, `region_name`, `latitude`, `longitude`, `height`

**Backwards compatible** — uses `entry.data.get()` with `None` defaults for existing entries.
